### PR TITLE
Us / fix/skill tooltip responsive

### DIFF
--- a/apps/gotask_ui/src/app/(portal)/user/components/skillInput.tsx
+++ b/apps/gotask_ui/src/app/(portal)/user/components/skillInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Typography, TextField, Grid, Stack, IconButton, Paper, Button } from "@mui/material";
+import { Box, Typography, TextField, Grid, Stack, IconButton, Paper, Button, Tooltip } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import StarIcon from "@mui/icons-material/Star";
@@ -195,9 +195,66 @@ const SkillInput: React.FC<SkillInputProps> = ({ userId, skills, onChange }) => 
                 >
                   <Box display="flex" gap={2}>
                     <Box>
-                      <Typography fontSize={14} fontWeight={600}>
-                        {skill.name}
-                      </Typography>
+                      <Box
+                        sx={{
+                          display: {
+                            xs: "block", // Show plain text on small screens
+                            sm: "none" // Hide plain text on larger screens
+                          }
+                        }}
+                      >
+                        <Typography
+                          fontSize={14}
+                          fontWeight={600}
+                          sx={{
+                            whiteSpace: "normal",
+                            wordBreak: "break-word"
+                          }}
+                        >
+                          {skill.name}
+                        </Typography>
+                      </Box>
+
+                      <Box
+                        sx={{
+                          display: {
+                            xs: "none", 
+                            sm: "block" 
+                          }
+                        }}
+                      >
+                        <Tooltip
+                          title={skill.name}
+                          placement="bottom-start"
+                          arrow
+                          PopperProps={{
+                            modifiers: [
+                              {
+                                name: "offset",
+                                options: {
+                                  offset: [10, 10]
+                                }
+                              }
+                            ]
+                          }}
+                        >
+                          <Typography
+                            fontSize={14}
+                            fontWeight={600}
+                            sx={{
+                              display: "block",
+                              maxWidth: "180px",
+                              whiteSpace: "nowrap",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              cursor: "pointer"
+                            }}
+                          >
+                            {skill.name}
+                          </Typography>
+                        </Tooltip>
+                      </Box>
+
                       <Typography fontSize={12} color="text.secondary">
                         {trans("proficiency")}: {PROFICIENCY_DESCRIPTIONS[skill.proficiency]}
                       </Typography>

--- a/apps/gotask_ui/src/app/(portal)/user/components/skillInput.tsx
+++ b/apps/gotask_ui/src/app/(portal)/user/components/skillInput.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Typography, TextField, Grid, Stack, IconButton, Paper, Button, Tooltip } from "@mui/material";
+import {
+  Box,
+  Typography,
+  TextField,
+  Grid,
+  Stack,
+  IconButton,
+  Paper,
+  Button,
+  Tooltip
+} from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import StarIcon from "@mui/icons-material/Star";
@@ -198,8 +208,8 @@ const SkillInput: React.FC<SkillInputProps> = ({ userId, skills, onChange }) => 
                       <Box
                         sx={{
                           display: {
-                            xs: "block", // Show plain text on small screens
-                            sm: "none" // Hide plain text on larger screens
+                            xs: "block",
+                            sm: "none"
                           }
                         }}
                       >
@@ -218,8 +228,8 @@ const SkillInput: React.FC<SkillInputProps> = ({ userId, skills, onChange }) => 
                       <Box
                         sx={{
                           display: {
-                            xs: "none", 
-                            sm: "block" 
+                            xs: "none",
+                            sm: "block"
                           }
                         }}
                       >


### PR DESCRIPTION
- Tooltip for skill name now appears only on larger screens (sm and up).
- On smaller screens (xs), tooltip is removed and full skill name is shown with proper wrapping to avoid overflow or ellipsis.
- Ensures better mobile experience while preserving tooltip behavior for desktop users.
